### PR TITLE
Add hidden priceItem UUid field to be used in the backend

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billables/form-helper.ts
+++ b/packages/esm-billing-app/src/billable-services/billables/form-helper.ts
@@ -11,6 +11,7 @@ export type BillableServicePayload = {
     paymentMode: string;
     price: string | number;
     name: string;
+    uuid: string;
   }>;
   serviceStatus: string;
   concept: string | number;
@@ -30,6 +31,7 @@ export const formatBillableServicePayloadForSubmission = (
       paymentMode: servicePrice.paymentMode.uuid,
       price: servicePrice.price.toFixed(2),
       name: servicePrice.paymentMode.name,
+      uuid: servicePrice.uuid,
     })),
     serviceStatus: formData.serviceStatus,
     concept: formData.concept.concept.uuid,
@@ -42,6 +44,7 @@ export const formatBillableServicePayloadForSubmission = (
 export function mapInputToPayloadSchema(service): BillableFormSchema {
   const servicePrices: Array<ServicePriceSchema> = service.servicePrices.map((price: any) => ({
     price: price.price,
+    uuid: price.uuid,
     paymentMode: {
       uuid: price.paymentMode?.uuid,
       name: price.paymentMode?.name,

--- a/packages/esm-billing-app/src/billable-services/billables/form-schemas.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/form-schemas.tsx
@@ -13,6 +13,7 @@ const ServiceConceptSchema = z.object({
 });
 
 export const servicePriceSchema = z.object({
+  uuid: z.string(),
   price: z.number().gt(0.01, 'Price must be greater than 0').min(0.01, 'Price must be at least 0.01'),
   paymentMode: z.object({ uuid: z.string(), name: z.string() }),
 });

--- a/packages/esm-billing-app/src/billable-services/billables/services/price.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/services/price.component.tsx
@@ -73,6 +73,13 @@ const PriceField: React.FC<PriceFieldProps> = ({ field, index, control, removeSe
       </ResponsiveWrapper>
       <ResponsiveWrapper>
         <Controller
+          name={`servicePrices.${index}.uuid`}
+          control={control}
+          render={({ field }) => (
+            <TextInput type="text" labelText="" defaultValue={field.value} invalid="" invalidText="" />
+          )}
+        />
+        <Controller
           name={`servicePrices.${index}.price`}
           control={control}
           render={({ field }) => (

--- a/packages/esm-billing-app/src/billable-services/billables/services/price.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/services/price.component.tsx
@@ -76,7 +76,7 @@ const PriceField: React.FC<PriceFieldProps> = ({ field, index, control, removeSe
           name={`servicePrices.${index}.uuid`}
           control={control}
           render={({ field }) => (
-            <TextInput type="text" labelText="" defaultValue={field.value} invalid="" invalidText="" />
+            <TextInput type="hidden" labelText="" defaultValue={field.value} invalid="" invalidText="" />
           )}
         />
         <Controller


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
